### PR TITLE
[network] Centralize LibraNet NetworkMessage framing and IO logic

### DIFF
--- a/network/benches/socket_bench.rs
+++ b/network/benches/socket_bench.rs
@@ -55,12 +55,13 @@ use netcore::{
     compat::IoCompat,
     transport::{memory::MemoryTransport, tcp::TcpTransport, Transport},
 };
+use network::{constants, protocols::wire::messaging::v1::network_message_frame_codec};
 use socket_bench_server::{
     build_memsocket_noise_transport, build_tcp_noise_transport, start_stream_server, Args,
 };
 use std::{fmt::Debug, io, time::Duration};
 use tokio::runtime::{Builder, Runtime};
-use tokio_util::codec::{Framed, LengthDelimitedCodec};
+use tokio_util::codec::Framed;
 
 const KiB: usize = 1 << 10;
 const MiB: usize = 1 << 20;
@@ -114,7 +115,8 @@ where
     let client_socket = runtime
         .block_on(client_transport.dial(server_peer_id, server_addr).unwrap())
         .unwrap();
-    let mut client_stream = Framed::new(IoCompat::new(client_socket), LengthDelimitedCodec::new());
+    let codec = network_message_frame_codec(constants::MAX_FRAME_SIZE);
+    let mut client_stream = Framed::new(IoCompat::new(client_socket), codec);
 
     // Benchmark client sending data to server.
     bench_client_send(b, msg_len, &mut client_stream);

--- a/network/src/peer_manager/error.rs
+++ b/network/src/peer_manager/error.rs
@@ -3,6 +3,7 @@
 
 //! Errors that originate from the PeerManager module
 
+use crate::protocols::wire::messaging::v1 as wire;
 use diem_network_address::NetworkAddress;
 use diem_types::PeerId;
 use futures::channel::{mpsc, oneshot};
@@ -36,6 +37,12 @@ pub enum PeerManagerError {
 
     #[error("Serialization error {0}")]
     LcsError(lcs::Error),
+
+    #[error("Error reading off wire: {0}")]
+    WireReadError(#[from] wire::ReadError),
+
+    #[error("Error writing to wire: {0}")]
+    WireWriteError(#[from] wire::WriteError),
 }
 
 impl PeerManagerError {

--- a/network/src/protocols/wire/messaging/v1/mod.rs
+++ b/network/src/protocols/wire/messaging/v1/mod.rs
@@ -1,13 +1,33 @@
 // Copyright (c) The Diem Core Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-//! This module defines the structs transported during the network messaging protocol v1.
-//! These should serialize as per the [specification](https://github.com/libra/libra/blob/master/specifications/network/messaging-v1.md)
+//! This module defines the DiemNet v1 message types, how they are
+//! serialized/deserialized, and provides a `Sink` and `Stream` implementation
+//! for sending `NetworkMessage`s over an abstract IO object (presumably a socket).
+//!
+//! The [DiemNet specification](https://github.com/libra/libra/blob/master/specifications/network/messaging-v1.md)
+//! describes in greater detail how these messages are sent and received
+//! over-the-wire.
 
 use crate::protocols::wire::handshake::v1::ProtocolId;
+use bytes::Bytes;
+use futures::{
+    io::{AsyncRead, AsyncWrite},
+    sink::Sink,
+    stream::Stream,
+};
+use netcore::compat::IoCompat;
+use pin_project::pin_project;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use thiserror::Error;
+use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 
 #[cfg(test)]
 mod test;
@@ -98,4 +118,142 @@ pub struct DirectSendMsg {
     /// Message payload.
     #[serde(with = "serde_bytes")]
     pub raw_msg: Vec<u8>,
+}
+
+/// Errors from reading and deserializing network messages off the wire.
+#[derive(Debug, Error)]
+pub enum ReadError {
+    #[error("network message stream: failed to deserialize network message frame: {0}, frame length: {1}, frame prefix: {2:?}")]
+    DeserializeError(#[source] lcs::Error, usize, Bytes),
+
+    #[error("network message stream: IO error while reading message: {0}")]
+    IoError(#[from] io::Error),
+}
+
+/// Errors from serializing and sending network messages on the wire.
+#[derive(Debug, Error)]
+pub enum WriteError {
+    #[error("network message sink: failed to serialize network message: {0}")]
+    SerializeError(#[source] lcs::Error),
+
+    #[error("network message sink: IO error while sending message: {0}")]
+    IoError(#[from] io::Error),
+}
+
+/// Returns a fully configured length-delimited codec for writing/reading
+/// serialized [`NetworkMessage`] frames to/from a socket.
+pub fn network_message_frame_codec(max_frame_size: usize) -> LengthDelimitedCodec {
+    LengthDelimitedCodec::builder()
+        .max_frame_length(max_frame_size)
+        .length_field_length(4)
+        .big_endian()
+        .new_codec()
+}
+
+/// A `Stream` of inbound `NetworkMessage`s read and deserialized from an
+/// underlying socket.
+#[pin_project]
+pub struct NetworkMessageStream<TReadSocket: AsyncRead> {
+    #[pin]
+    framed_read: FramedRead<IoCompat<TReadSocket>, LengthDelimitedCodec>,
+}
+
+impl<TReadSocket: AsyncRead> NetworkMessageStream<TReadSocket> {
+    pub fn new(socket: TReadSocket, max_frame_size: usize) -> Self {
+        let frame_codec = network_message_frame_codec(max_frame_size);
+        let compat_socket = IoCompat::new(socket);
+        let framed_read = FramedRead::new(compat_socket, frame_codec);
+        Self { framed_read }
+    }
+}
+
+impl<TReadSocket: AsyncRead> Stream for NetworkMessageStream<TReadSocket> {
+    type Item = Result<NetworkMessage, ReadError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.project().framed_read.poll_next(cx) {
+            Poll::Ready(Some(Ok(frame))) => {
+                let frame = frame.freeze();
+
+                match lcs::from_bytes(&frame) {
+                    Ok(message) => Poll::Ready(Some(Ok(message))),
+                    // Failed to deserialize the NetworkMessage
+                    Err(err) => {
+                        let mut frame = frame;
+                        let frame_len = frame.len();
+                        // Keep a few bytes from the frame for debugging
+                        frame.truncate(8);
+                        let err = ReadError::DeserializeError(err, frame_len, frame);
+                        Poll::Ready(Some(Err(err)))
+                    }
+                }
+            }
+            Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(ReadError::IoError(err)))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// A `Sink` of outbound `NetworkMessage`s that will be serialized and sent over
+/// an underlying socket.
+#[pin_project]
+pub struct NetworkMessageSink<TWriteSocket: AsyncWrite> {
+    #[pin]
+    framed_write: FramedWrite<IoCompat<TWriteSocket>, LengthDelimitedCodec>,
+}
+
+impl<TWriteSocket: AsyncWrite> NetworkMessageSink<TWriteSocket> {
+    pub fn new(socket: TWriteSocket, max_frame_size: usize) -> Self {
+        let frame_codec = network_message_frame_codec(max_frame_size);
+        let compat_socket = IoCompat::new(socket);
+        let framed_write = FramedWrite::new(compat_socket, frame_codec);
+        Self { framed_write }
+    }
+}
+
+#[cfg(test)]
+impl<TWriteSocket: AsyncWrite + Unpin> NetworkMessageSink<TWriteSocket> {
+    pub async fn send_raw_frame(&mut self, frame: Bytes) -> Result<(), WriteError> {
+        use futures::sink::SinkExt;
+        self.framed_write
+            .send(frame)
+            .await
+            .map_err(WriteError::IoError)
+    }
+}
+
+impl<TWriteSocket: AsyncWrite> Sink<&NetworkMessage> for NetworkMessageSink<TWriteSocket> {
+    type Error = WriteError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project()
+            .framed_write
+            .poll_ready(cx)
+            .map_err(WriteError::IoError)
+    }
+
+    fn start_send(self: Pin<&mut Self>, message: &NetworkMessage) -> Result<(), Self::Error> {
+        let frame = lcs::to_bytes(message).map_err(WriteError::SerializeError)?;
+        let frame = Bytes::from(frame);
+
+        self.project()
+            .framed_write
+            .start_send(frame)
+            .map_err(WriteError::IoError)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project()
+            .framed_write
+            .poll_flush(cx)
+            .map_err(WriteError::IoError)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project()
+            .framed_write
+            .poll_close(cx)
+            .map_err(WriteError::IoError)
+    }
 }

--- a/network/src/protocols/wire/messaging/v1/test.rs
+++ b/network/src/protocols/wire/messaging/v1/test.rs
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::testutils::fake_socket::{ReadOnlyTestSocket, ReadWriteTestSocket};
+use futures::{executor::block_on, future, sink::SinkExt, stream::StreamExt};
+use lcs::test_helpers::assert_canonical_encode_decode;
+use memsocket::MemorySocket;
+use proptest::{collection::vec, prelude::*};
 
 // Ensure serialization of ProtocolId enum takes 1 byte.
 #[test]
@@ -31,7 +36,7 @@ fn rpc_request() -> lcs::Result<()> {
     };
     assert_eq!(
         lcs::to_bytes(&rpc_request)?,
-        // [0] -> protocol_idx
+        // [0] -> protocol_id
         // [25, 0, 0, 0] -> request_id
         // [0] -> priority
         // [4] -> length of raw_request
@@ -39,4 +44,179 @@ fn rpc_request() -> lcs::Result<()> {
         vec![0, 25, 0, 0, 0, 0, 4, 0, 1, 2, 3]
     );
     Ok(())
+}
+
+#[test]
+fn libranet_wire_test_vectors() {
+    let message = NetworkMessage::DirectSendMsg(DirectSendMsg {
+        protocol_id: ProtocolId::MempoolDirectSend,
+        priority: 0,
+        raw_msg: Vec::from("hello world"),
+    });
+    let message_bytes = [
+        // [0, 0, 0, 15] -> frame length
+        // [3] -> network message type
+        // [2] -> protocol_id
+        // [0] -> priority
+        // [11] -> raw message length
+        // [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100] -> raw message bytes
+        0_u8, 0, 0, 15, 3, 2, 0, 11, 104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100,
+    ];
+
+    // test reading and deserializing gives us the expected message
+
+    let socket_rx = ReadOnlyTestSocket::new(&message_bytes);
+    let message_rx = NetworkMessageStream::new(socket_rx, 128);
+
+    let recv_messages = block_on(message_rx.collect::<Vec<_>>());
+    let recv_messages = recv_messages
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    assert_eq!(vec![message.clone()], recv_messages);
+
+    // test serializing and writing gives us the expected bytes
+
+    let (mut socket_tx, _socket_rx) = ReadWriteTestSocket::new_pair();
+    let mut write_buf = Vec::new();
+    socket_tx.save_writing(&mut write_buf);
+
+    let mut message_tx = NetworkMessageSink::new(socket_tx, 128);
+    block_on(message_tx.send(&message)).unwrap();
+
+    assert_eq!(&write_buf, &message_bytes);
+}
+
+#[test]
+fn send_fails_when_larger_than_frame_limit() {
+    let (memsocket_tx, _memsocket_rx) = MemorySocket::new_pair();
+    let mut message_tx = NetworkMessageSink::new(memsocket_tx, 64);
+
+    // attempting to send an outbound message larger than your frame size will
+    // return an Err
+    let message = NetworkMessage::DirectSendMsg(DirectSendMsg {
+        protocol_id: ProtocolId::ConsensusRpc,
+        priority: 0,
+        raw_msg: vec![0; 123],
+    });
+    block_on(message_tx.send(&message)).unwrap_err();
+}
+
+#[test]
+fn recv_fails_when_larger_than_frame_limit() {
+    let (memsocket_tx, memsocket_rx) = MemorySocket::new_pair();
+    // sender won't error b/c their max frame size is larger
+    let mut message_tx = NetworkMessageSink::new(memsocket_tx, 128);
+    // receiver will reject the message b/c the frame size is > 64 bytes max
+    let mut message_rx = NetworkMessageStream::new(memsocket_rx, 64);
+
+    let message = NetworkMessage::DirectSendMsg(DirectSendMsg {
+        protocol_id: ProtocolId::ConsensusRpc,
+        priority: 0,
+        raw_msg: vec![0; 80],
+    });
+    let f_send = message_tx.send(&message);
+    let f_recv = message_rx.next();
+
+    let (_, res_message) = block_on(future::join(f_send, f_recv));
+    res_message.unwrap().unwrap_err();
+}
+
+fn arb_rpc_request(max_frame_size: usize) -> impl Strategy<Value = RpcRequest> {
+    (
+        any::<ProtocolId>(),
+        any::<RequestId>(),
+        any::<Priority>(),
+        (0..max_frame_size).prop_map(|size| vec![0u8; size]),
+    )
+        .prop_map(
+            |(protocol_id, request_id, priority, raw_request)| RpcRequest {
+                protocol_id,
+                request_id,
+                priority,
+                raw_request,
+            },
+        )
+}
+
+fn arb_rpc_response(max_frame_size: usize) -> impl Strategy<Value = RpcResponse> {
+    (
+        any::<RequestId>(),
+        any::<Priority>(),
+        (0..max_frame_size).prop_map(|size| vec![0u8; size]),
+    )
+        .prop_map(|(request_id, priority, raw_response)| RpcResponse {
+            request_id,
+            priority,
+            raw_response,
+        })
+}
+
+fn arb_direct_send_msg(max_frame_size: usize) -> impl Strategy<Value = DirectSendMsg> {
+    let args = (
+        any::<ProtocolId>(),
+        any::<Priority>(),
+        (0..max_frame_size).prop_map(|size| vec![0u8; size]),
+    );
+    args.prop_map(|(protocol_id, priority, raw_msg)| DirectSendMsg {
+        protocol_id,
+        priority,
+        raw_msg,
+    })
+}
+
+fn arb_network_message(max_frame_size: usize) -> impl Strategy<Value = NetworkMessage> {
+    prop_oneof![
+        any::<ErrorCode>().prop_map(NetworkMessage::Error),
+        arb_rpc_request(max_frame_size).prop_map(NetworkMessage::RpcRequest),
+        arb_rpc_response(max_frame_size).prop_map(NetworkMessage::RpcResponse),
+        arb_direct_send_msg(max_frame_size).prop_map(NetworkMessage::DirectSendMsg),
+    ]
+    .prop_filter("larger than max frame size", move |msg| {
+        lcs::serialized_size(&msg).unwrap() <= max_frame_size
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(100))]
+
+    #[test]
+    fn network_message_canonical_serialization(message in any::<NetworkMessage>()) {
+        assert_canonical_encode_decode(message);
+    }
+
+    /// Test that NetworkMessageSink and NetworkMessageStream can understand each
+    /// other and fully preserve the NetworkMessages being sent
+    #[test]
+    fn network_message_socket_roundtrip(
+        messages in vec(arb_network_message(128), 1..20),
+        fragmented_read in any::<bool>(),
+        fragmented_write in any::<bool>(),
+    ) {
+        let (mut socket_tx, mut socket_rx) = ReadWriteTestSocket::new_pair();
+
+        if fragmented_read {
+            socket_rx.set_fragmented_read();
+        }
+        if fragmented_write {
+            socket_tx.set_fragmented_write();
+        }
+
+        let mut message_tx = NetworkMessageSink::new(socket_tx, 128);
+        let message_rx = NetworkMessageStream::new(socket_rx, 128);
+
+        let f_send_all = async {
+            for message in &messages {
+                message_tx.send(&message).await.unwrap();
+            }
+            message_tx.close().await.unwrap();
+        };
+        let f_recv_all = message_rx.collect::<Vec<_>>();
+
+        let (_, recv_messages) = block_on(future::join(f_send_all, f_recv_all));
+
+        for (message, recv_message) in messages.into_iter().zip(recv_messages.into_iter()) {
+            assert_eq!(message, recv_message.unwrap());
+        }
+    }
 }

--- a/specifications/network/messaging-v1.md
+++ b/specifications/network/messaging-v1.md
@@ -118,4 +118,28 @@ The serialized `NetworkMsg`s over-the-wire then look like a sequence of length-p
 [u32-length-prefix] || [serialized-message-bytes] || ..
 ```
 
+### Maximum Frame Size
+
+Each `serialized-message-bytes` MUST be less than or equal to 8 MiB in size (8388608 bytes). Note that this calculated length does NOT include the `u32-length-prefix`. LibraNet servers should reject inbound messages larger than the 8 MiB limit and LibraNet clients MUST NOT send outbound messages larger than the 8 MiB limit.
+
+As an example, basic pseudocode for reading a single LibraNet message might look like:
+
+```rust
+const MAX_DIEMNET_FRAME_LEN: u32 = 8388608; // 8 MiB
+
+// read the 4-byte length prefix first
+let length_prefix: u32 = noise_socket.read(4).to_host_endian();
+
+// reject messages that are too large
+if length_prefix > MAX_DIEMNET_FRAME_LEN {
+    reject;
+}
+
+// read the actual lcs-serialized message
+let message_bytes = noise_socket.read(length_prefix);
+
+// deserialize the message
+let message = lcs::from_bytes(message_bytes);
+```
+
 (TODO(philiphayes): add streaming RPC protocol when supported)


### PR DESCRIPTION
I'm going to try to spend some time refactoring the Peer actor to reduce the number of actors/tasks and hopefully simplify the life-cycle a bit. This diff mostly moves some of the socket/IO logic out of the Peer actor and centralizes the logic in one place, where we can use it elsewhere. It's also easier to test/fuzz some of the IO logic in isolation like this. In doing so, we can also replace a lot of the bespoke `LengthDelimitedCodec` and `Framed` usage in tests and fuzzers.

+ Add `NetworkMessageStream` and `NetworkMessageSink` adapters around socket-like objects.

+ `NetworkMessageStream` adapts a read socket (`AsyncRead`) into a stream of `NetworkMessage`s and handles all of the underlying framing, deserializing, and reading of `NetworkMessage`s from the socket.

+ Likewise, `NetworkMessageSink` adapts a write socket (`AsyncWrite`) into a sink of `NetworkMessage`s, i.e., something you can just send `NetworkMessage`s on and it will handle the underlying framing, serializing, and writing of `NetworkMessage`s into the socket.

+ The Sink/Stream is split into two separate structs so we can send and receive messages concurrently without coordination. Right now, our Peer actor splits the underlying socket with a `tokio::io::split`, which uses a mutex under-the-hood to serialize acces to the socket. However, with a trait, we can probably get rid of this `tokio::io::split`.

+ If we want, we can remove our dependency on tokio-util's length-delimited codec and hopefully simplify this a bit.

+ Clarify a missing piece in the LibraNet specs around the maximum frame size.

+ The writeable fake sockets now support an option to enable fragmented writes, which forces writes to happen one byte at a time. Like the fragmented read option, this helps ensure our socket logic is properly handling partial reads and writes.