### PR TITLE
[async_client] Include StatusCode in Error::InvalidHTTPStatus

### DIFF
--- a/client/json-rpc/src/async_client/client.rs
+++ b/client/json-rpc/src/async_client/client.rs
@@ -469,8 +469,11 @@ impl<R: RetryStrategy> Client<R> {
             .send()
             .await
             .map_err(Error::NetworkError)?;
-        if resp.status() != 200 {
-            return Err(Error::InvalidHTTPStatus(format!("{:#?}", resp)));
+        if !resp.status().is_success() {
+            return Err(Error::InvalidHTTPStatus(
+                format!("{:#?}", resp),
+                resp.status(),
+            ));
         }
         resp.json().await.map_err(Error::InvalidHTTPResponse)
     }

--- a/client/json-rpc/src/async_client/error.rs
+++ b/client/json-rpc/src/async_client/error.rs
@@ -8,7 +8,7 @@ pub enum Error {
     // Error when send http request failed
     NetworkError(reqwest::Error),
     // Response http status is not 200
-    InvalidHTTPStatus(String), // reqwest::Response),
+    InvalidHTTPStatus(String, reqwest::StatusCode),
     // Response body can't be decoded as json-rpc response
     InvalidHTTPResponse(reqwest::Error),
     // Decoded JSON-RPC does not match JSON-RPC spec


### PR DESCRIPTION
## Motivation

Currently, `Error::InvalidHTTPStatus` does. not expose the http status code, therefore the client users cannot take cation based on the nature of the failure. For instance, it it is a 4xx type of error, we know that a retry will likely not result in a different outcome. On the other hand, a 5xx error could signal a server issue and probably we'd like to retry.

## Test Plan
Proposed change does not alter behavior. Verified current tests are passing.

