### PR TITLE
[json-rpc] add chain id, latest ledger version and timestamp to http response header

### DIFF
--- a/json-rpc/API-CHANGELOG.md
+++ b/json-rpc/API-CHANGELOG.md
@@ -12,6 +12,17 @@ Please add the API change in the following format:
 - <describle another change of the API>
 
 ```
+
+# 2020-12-07 Add a `X-Diem-Chain-Id`, `X-Diem-Ledger-Version` and `X-Diem-Ledger-TimestampUsec` to http response header
+
+The added headers are same with JSON-RPC response json same name fields. They are added for client to know chain id and server's latest block version and timestamp without decoding body json.
+
+* `X-Diem-Chain-Id`: chain id of server
+* `X-Diem-Ledger-Version`: the latest ledger version when the request hit server.
+* `X-Diem-Ledger-TimestampUsec`: the latest ledger version's timestamp in usec when the request hit server.
+
+All values are string type.
+
 # 2020-11-09 Add a `get_transactions_with_proofs` API
 
 This allows to create verifying clients that do not need to blindly trust the fullnode they connect to.

--- a/json-rpc/json-rpc-spec.md
+++ b/json-rpc/json-rpc-spec.md
@@ -93,3 +93,13 @@ Allows:
 * Origin: any
 * Request-Method: POST
 * Request-Headers: content-type
+
+## HTTP Response Headers Extensions
+
+All Diem JSON-RPC server responses include the following headers:
+
+* `X-Diem-Chain-Id`: network chain id, e.g. testnet chain id is 2
+* `X-Diem-Ledger-Version`: server-side latest ledger version number
+* `X-Diem-Ledger-TimestampUsec`: server-side latest ledger timestamp microseconds
+
+These headers are similar with [Diem extensions](#diem-extensions), except the value type is all string.

--- a/json-rpc/src/tests/unit_tests.rs
+++ b/json-rpc/src/tests/unit_tests.rs
@@ -933,6 +933,27 @@ fn test_json_rpc_protocol_invalid_requests() {
     for (name, request, expected) in calls {
         let resp = client.post(&url).json(&request).send().unwrap();
         assert_eq!(resp.status(), 200);
+        let headers = resp.headers().clone();
+        assert_eq!(
+            headers.get("X-Diem-Chain-Id").unwrap().to_str().unwrap(),
+            "4"
+        );
+        assert_eq!(
+            headers
+                .get("X-Diem-Ledger-Version")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            version.to_string()
+        );
+        assert_eq!(
+            headers
+                .get("X-Diem-Ledger-TimestampUsec")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            timestamp.to_string()
+        );
 
         let resp_json: serde_json::Value = resp.json().unwrap();
         assert_eq!(expected, resp_json, "test: {}", name);

--- a/json-rpc/types/src/response.rs
+++ b/json-rpc/types/src/response.rs
@@ -4,6 +4,11 @@
 use crate::errors::JsonRpcError;
 use serde::{Deserialize, Serialize};
 
+// http response header names
+pub const X_DIEM_CHAIN_ID: &str = "X-Diem-Chain-Id";
+pub const X_DIEM_VERSION_ID: &str = "X-Diem-Ledger-Version";
+pub const X_DIEM_TIMESTAMP_USEC_ID: &str = "X-Diem-Ledger-TimestampUsec";
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct JsonRpcResponse {
     pub diem_chain_id: u8,


### PR DESCRIPTION
## Motivation

These information is in JSON response body too, but when the request is batch request, client side need decode the array of the response first to get single response object for accessing the information. 
These information are useful to determine whether the server response is stale or not, use response header will be easier to decode and can ignore body if client found the ledger version is stale (client side tracks latest known version).

### Have you read the [Contributing Guidelines on pull requests](https://github.com/libra/libra/blob/master/CONTRIBUTING.md#pull-requests)?

Yes

## Test Plan

Unit and integration test
